### PR TITLE
Add Qazaq and Ukrainian languages support, fix issues and add exception handling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "cyrillic-morpher",
 	"name": "Cyrillic Morpher",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"minAppVersion": "0.15.0",
 	"description": "This is a plugin to generate cases for cyrillic named files. Update your aliases with command.",
 	"author": "vanadium23",

--- a/src/aliasater.ts
+++ b/src/aliasater.ts
@@ -47,6 +47,9 @@ export class CyrillicGenerator implements CyrillicAliasater {
 		const filename = ctx.file?.basename;
 		const cases = await this.morpher.generateCases(filename, plural);
 		const newAliases = cases.filter((alias) => alias !== filename);
+		if (newAliases.length === 0) {
+			return;
+		}
 		// update frontmatter aliases
 		await this.app.fileManager.processFrontMatter(ctx.file, (frontmatter) => {
 			const mergedAliases = mergeAliases(

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { CyrillicMorperSettingTab } from './settings_tab';
 // Remember to rename these classes and interfaces!
 const DEFAULT_SETTINGS: CyrillicMorperSettings = {
 	morpherApiKey: null,
+	morpherLanguage: 'russian'
 };
 
 export default class ObsidianCyrillicMorper extends Plugin {

--- a/src/morpher.ts
+++ b/src/morpher.ts
@@ -37,6 +37,6 @@ export class CyrillicMorpher implements Morpher {
 				})
 			);
 		}
-		return aliases;
+		return [...new Set<string>(aliases)];
 	}
 }

--- a/src/morpher.ts
+++ b/src/morpher.ts
@@ -36,13 +36,24 @@ export class CyrillicMorpher implements Morpher {
 		}
 
 		// TODO: move to settings
-		const cases = [
+		let cases = [
 			'accusative',
 			'dative',
 			'genitive',
 			'instrumental',
-			'prepositional',
 		];
+		if (this.settings.morpherLanguage === 'qazaq') {
+			cases.push('locative');
+			cases.push('ablative');
+		}
+		else if (this.settings.morpherLanguage === 'ukrainian') {
+			cases.push('prepositional');
+			cases.push('vocative');
+		}
+		else if (this.settings.morpherLanguage === 'russian') {
+			cases.push('prepositional');
+		}
+
 		let aliases = cases.map((caseName) => {
 			return result[caseName];
 		});

--- a/src/morpher.ts
+++ b/src/morpher.ts
@@ -1,3 +1,4 @@
+import { Notice } from 'obsidian';
 import { CyrillicMorperSettings } from './settings';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -20,7 +21,20 @@ export class CyrillicMorpher implements Morpher {
 		});
 		let morpher = client[this.settings.morpherLanguage];
 
-		const result = await morpher.declension(string);
+		let result: any = null;
+		try {
+			result = await morpher.declension(string);
+		}
+		catch(e) {
+			if (e.message === 'Failed to fetch') {
+				new Notice('Please check if your token is correct!');
+			}
+			else {
+				new Notice(e.message);
+			}
+			return [];
+		}
+
 		// TODO: move to settings
 		const cases = [
 			'accusative',

--- a/src/morpher.ts
+++ b/src/morpher.ts
@@ -8,17 +8,17 @@ interface Morpher {
 }
 
 export class CyrillicMorpher implements Morpher {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	morpher: any;
+	settings: CyrillicMorperSettings;
 
 	constructor(settings: CyrillicMorperSettings) {
-		this.morpher = new ws3Morpher({
-			token: settings.morpherApiKey,
-		});
+		this.settings = settings;
 	}
 
 	async generateCases(string: string, plural = false): Promise<string[]> {
-		const result = await this.morpher.russian.declension(string);
+		const morpher = new ws3Morpher({
+			token: this.settings.morpherApiKey,
+		});
+		const result = await morpher.russian.declension(string);
 		// TODO: move to settings
 		const cases = [
 			'accusative',

--- a/src/morpher.ts
+++ b/src/morpher.ts
@@ -15,10 +15,12 @@ export class CyrillicMorpher implements Morpher {
 	}
 
 	async generateCases(string: string, plural = false): Promise<string[]> {
-		const morpher = new ws3Morpher({
+		const client = new ws3Morpher({
 			token: this.settings.morpherApiKey,
 		});
-		const result = await morpher.russian.declension(string);
+		let morpher = client[this.settings.morpherLanguage];
+
+		const result = await morpher.declension(string);
 		// TODO: move to settings
 		const cases = [
 			'accusative',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,3 +1,4 @@
 export interface CyrillicMorperSettings {
 	morpherApiKey: string | null;
+	morpherLanguage: string;
 }

--- a/src/settings_tab.ts
+++ b/src/settings_tab.ts
@@ -34,5 +34,18 @@ export class CyrillicMorperSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+		new Setting(containerEl)
+			.setName('Language')
+			.addDropdown(dropDown => {
+				dropDown.addOption('qazaq', 'Qazaq');
+				dropDown.addOption('russian', 'Russian');
+				dropDown.addOption('ukrainian', 'Ukrainian');
+				dropDown.setValue(this.plugin.settings.morpherLanguage || 'russian')
+				dropDown.onChange(async (value) =>	{
+					this.plugin.settings.morpherLanguage = value;
+					await this.plugin.saveSettings();
+				})
+			})
 	}
 }


### PR DESCRIPTION
Hello!

This PR:
1. adds Qazaq and Ukrainian languages support.
2. fixes issues #3, #4
3. adds exception handling

## New languages

Add Qazaq and Ukrainian languages support.
Qazaq language has 6 word forms incl. locative and ablative.
Ukrainian language gas 6 word forms incl. prepositional and vocative.

New settings window:
![Screenshot from 2024-05-12 19-11-37](https://github.com/vanadium23/obsidian-cyrillic-morpher/assets/6889805/1342f7a8-7729-4e82-9ca8-e7a927eb797b)

Demo:
[New languages demo.webm](https://github.com/vanadium23/obsidian-cyrillic-morpher/assets/6889805/ccf64051-5bdb-4003-9e08-c60e5620f31e)



## Fix for #3

[New morphing without douplicates.webm](https://github.com/vanadium23/obsidian-cyrillic-morpher/assets/6889805/7335103a-7f31-481c-a98a-dacd28ebe2c9)


## Exception handling
[Exception handling.webm](https://github.com/vanadium23/obsidian-cyrillic-morpher/assets/6889805/9a3f18cf-514f-4f81-a653-5d496a487e28)
